### PR TITLE
fix(seo): 記事の構造化データ日付をJST基準に統一する

### DIFF
--- a/src/lib/vecta/seo.test.ts
+++ b/src/lib/vecta/seo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  buildArticleJsonLd,
   buildCanonicalUrl,
   buildOrganizationJsonLd,
   buildSitemapXml,
@@ -24,5 +25,19 @@ describe('seo helpers', () => {
 
   test('renders sitemap lastmod dates in JST regardless of build TZ', () => {
     expect(buildSitemapXml()).toContain('<lastmod>2026-07-10</lastmod>')
+  })
+
+  test('renders article structured-data dates in JST', () => {
+    const jsonLd = buildArticleJsonLd({
+      slug: 'timezone-test',
+      title: 'タイムゾーンテスト',
+      description: '記事の日付を JST 基準で出力する',
+      publishedAt: new Date('2026-07-13T00:00:00+09:00'),
+      updatedAt: new Date('2026-07-14T00:00:00+09:00'),
+      heroImage: '/article/timezone-test.png',
+    })
+
+    expect(jsonLd.datePublished).toBe('2026-07-13')
+    expect(jsonLd.dateModified).toBe('2026-07-14')
   })
 })

--- a/src/lib/vecta/seo.ts
+++ b/src/lib/vecta/seo.ts
@@ -132,8 +132,8 @@ export const buildArticleJsonLd = (article: ArticlePageMeta): JsonLd => ({
   '@type': 'Article',
   headline: article.title,
   description: article.description,
-  datePublished: article.publishedAt.toISOString(),
-  dateModified: (article.updatedAt ?? article.publishedAt).toISOString(),
+  datePublished: formatDateJst(article.publishedAt),
+  dateModified: formatDateJst(article.updatedAt ?? article.publishedAt),
   image: buildAbsoluteUrl(article.heroImage),
   mainEntityOfPage: buildCanonicalUrl(`/article/${article.slug}/`),
   publisher: {


### PR DESCRIPTION
## チケット

- close #44

## Why

記事の公開日を JST の暦日として管理している一方、JSON-LD の `datePublished` と `dateModified` は UTC の ISO 文字列へ変換され、前日の日時として出力されていました。

## What

### As Is

- JSON-LD の記事日付が `2026-07-12T15:00:00.000Z` のような UTC 表記になる

### To Be

- sitemap と共通の JST 日付 formatter を使用し、JSON-LD の記事日付を `2026-07-13` 形式で出力する
- 公開日と更新日の JST 出力を回帰テストで保証する

## How

- `buildArticleJsonLd` の日付変換を `formatDateJst` に統一
- UTC / JST の両環境で SEO helper test を確認
- UTC build の生成物で記事表示、sitemap、JSON-LD の日付を確認

## Notes

- `TZ=UTC bun run check`: 32 tests passed、0 errors、0 warnings
- `TZ=UTC bun run build`: passed